### PR TITLE
Add new context_question fields

### DIFF
--- a/docs/data-sources/context_question.md
+++ b/docs/data-sources/context_question.md
@@ -27,6 +27,7 @@ A resourcely ContextQuestion
 - `excluded_blueprint_series` (Set of String) series_id for Blueprints exempt from this context question even though those blueprints belong to the context question's blueprint_categories
 - `id` (String) UUID for this version.
 - `label` (String)
+- `priority` (Number) Priority of this question, relative to others. 0=high, 1=medium, 2=low
 - `prompt` (String)
 - `qtype` (String)
 - `regex_pattern` (String) Regex validation for the acceptable answers to the context question

--- a/docs/resources/context_question.md
+++ b/docs/resources/context_question.md
@@ -28,6 +28,7 @@ A Resourcely Context Question
 - `blueprint_categories` (Set of String)
 - `excluded_blueprint_series` (Set of String) series_id for Blueprints exempt from this context question even though those blueprints belong to the context question's blueprint_categories
 - `label` (String)
+- `priority` (Number) Priority of this question, relative to others. 0=high, 1=medium, 2=low
 - `regex_pattern` (String) Regex validation for the acceptable answers to the context question
 
 ### Read-Only

--- a/internal/client/context_question.go
+++ b/internal/client/context_question.go
@@ -11,6 +11,7 @@ type ContextQuestionsService service
 
 type NewContextQuestion struct {
 	CommonContextQuestionFields
+	IsTerraformManaged bool `json:"is_terraform_managed"`
 }
 
 type UpdatedContextQuestion struct {
@@ -28,6 +29,7 @@ type CommonContextQuestionFields struct {
 	BlueprintCategories     []string       `json:"blueprint_categories"`
 	RegexPattern            string         `json:"regex_pattern"`
 	ExcludedBlueprintSeries []string       `json:"excluded_blueprint_series"`
+	Priority                int64          `json:"priority"`
 }
 
 type ContextQuestion struct {

--- a/internal/provider/context_question_common.go
+++ b/internal/provider/context_question_common.go
@@ -27,6 +27,7 @@ type ContextQuestionResourceModel struct {
 	BlueprintCategories     types.Set       `tfsdk:"blueprint_categories"`
 	RegexPattern            types.String    `tfsdk:"regex_pattern"`
 	ExcludedBlueprintSeries types.Set       `tfsdk:"excluded_blueprint_series"`
+	Priority                types.Int64     `tfsdk:"priority"`
 }
 
 func FlattenContextQuestion(contextQuestion *client.ContextQuestion) ContextQuestionResourceModel {
@@ -40,6 +41,7 @@ func FlattenContextQuestion(contextQuestion *client.ContextQuestion) ContextQues
 	data.Qtype = types.StringValue(contextQuestion.Qtype)
 	data.AnswerFormat = types.StringValue(contextQuestion.AnswerFormat)
 	data.Scope = types.StringValue(contextQuestion.Scope)
+	data.Priority = types.Int64Value(contextQuestion.Priority)
 
 	var answerChoices = make([]AnswerChoices, 0)
 	for _, answerChoice := range contextQuestion.AnswerChoices {

--- a/internal/provider/context_question_data_source.go
+++ b/internal/provider/context_question_data_source.go
@@ -92,6 +92,10 @@ func (d *ContextQuestionDataSource) Schema(_ context.Context, _ datasource.Schem
 				Computed:            true,
 				MarkdownDescription: "series_id for Blueprints exempt from this context question even though those blueprints belong to the context question's blueprint_categories",
 			},
+			"priority": schema.Int64Attribute{
+				MarkdownDescription: "Priority of this question, relative to others. 0=high, 1=medium, 2=low",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/context_question_data_source_test.go
+++ b/internal/provider/context_question_data_source_test.go
@@ -24,6 +24,7 @@ func TestAccContextQuestionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "answer_choices.0.label", "tenant-context Option 1"),
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "label", "marketing"),
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "regex_pattern", "regex"),
+					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "priority", "2"),
 				),
 			},
 		},
@@ -40,6 +41,7 @@ resource "resourcely_context_question" "basic" {
 	label = "marketing"
 	regex_pattern = "regex"
 	excluded_blueprint_series = []
+	priority = 2
 }
 
 data "resourcely_context_question" "by_series_id" {

--- a/internal/provider/context_question_resource.go
+++ b/internal/provider/context_question_resource.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -152,6 +154,15 @@ func (r *ContextQuestionResource) Schema(_ context.Context, _ resource.SchemaReq
 				Optional:            true,
 				Computed:            true,
 			},
+			"priority": schema.Int64Attribute{
+				Default:             int64default.StaticInt64(0),
+				MarkdownDescription: "Priority of this question, relative to others. 0=high, 1=medium, 2=low",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 2),
+				},
+			},
 		},
 	}
 }
@@ -188,6 +199,7 @@ func (r *ContextQuestionResource) Create(ctx context.Context, req resource.Creat
 	// Create the resource
 	newContextQuestion := &client.NewContextQuestion{
 		CommonContextQuestionFields: r.buildCommonFields(ctx, plan),
+		IsTerraformManaged:          true,
 	}
 
 	ContextQuestion, _, err := r.service.CreateContextQuestion(ctx, newContextQuestion)
@@ -299,6 +311,7 @@ func (r *ContextQuestionResource) buildCommonFields(ctx context.Context, plan Co
 		BlueprintCategories:     nil,
 		RegexPattern:            plan.RegexPattern.ValueString(),
 		ExcludedBlueprintSeries: nil,
+		Priority:                plan.Priority.ValueInt64(),
 	}
 
 	var answerChoices []client.AnswerChoice

--- a/internal/provider/context_question_resource_test.go
+++ b/internal/provider/context_question_resource_test.go
@@ -26,6 +26,7 @@ func TestAccContextQuestionResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "answer_choices.0.label", "tenant-context Option 1"),
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "label", "marketing"),
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "regex_pattern", `regex`),
+					resource.TestCheckResourceAttr("resourcely_context_question.basic", "priority", "2"),
 				),
 			},
 			// ImportState testing
@@ -61,6 +62,7 @@ func TestAccContextQuestionResource_useDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "prompt", "what is your prompt?"),
 					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "qtype", "QTYPE_TEXT"),
 					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "blueprint_categories.0", "BLUEPRINT_BLOB_STORAGE"),
+					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "priority", "0"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -93,6 +95,7 @@ resource "resourcely_context_question" "basic" {
 	label = "marketing"
 	regex_pattern = "regex"
 	excluded_blueprint_series = []
+	priority = 2
 }
 `, prompt)
 }


### PR DESCRIPTION
# What?
Add `is_terraform_managed` and `priority` to `resourcely_context_question`

# Testing?
Added to existing acceptance tests, plus manual testing for the validation.

![image](https://github.com/Resourcely-Inc/terraform-provider-resourcely/assets/137814572/757a6e3a-8ef7-42e9-b8bd-106916976641)
