### PR TITLE
add blueprint.excluded_context_question_series

### DIFF
--- a/docs/data-sources/blueprint.md
+++ b/docs/data-sources/blueprint.md
@@ -25,6 +25,7 @@ A resourcely blueprint
 - `cloud_provider` (String)
 - `content` (String)
 - `description` (String)
+- `excluded_context_question_series` (Set of String) series_id for context questions that won't be used with this blueprint, even if this blueprint matches the context questions' blueprint_categories
 - `guidance` (String)
 - `id` (String) UUID for this version.
 - `labels` (Set of String)

--- a/docs/resources/blueprint.md
+++ b/docs/resources/blueprint.md
@@ -25,6 +25,7 @@ A Resourcely Blueprint
 
 - `categories` (Set of String)
 - `description` (String)
+- `excluded_context_question_series` (Set of String) series_id for context questions that won't be used with this blueprint, even if this blueprint matches the context questions' blueprint_categories
 - `guidance` (String)
 - `labels` (Set of String)
 - `scope` (String)

--- a/internal/client/blueprints.go
+++ b/internal/client/blueprints.go
@@ -30,12 +30,13 @@ type UpdatedBlueprint struct {
 }
 
 type CommonBlueprintFields struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Content     string   `json:"content"`
-	Categories  []string `json:"categories"`
-	Guidance    string   `json:"guidance"`
-	Labels      []Label  `json:"labels"`
+	Name                          string   `json:"name"`
+	Description                   string   `json:"description,omitempty"`
+	Content                       string   `json:"content"`
+	Categories                    []string `json:"categories"`
+	Guidance                      string   `json:"guidance"`
+	Labels                        []Label  `json:"labels"`
+	ExcludedContextQuestionSeries []string `json:"excluded_context_question_series"`
 }
 
 func (s *BlueprintsService) GetBlueprintBySeriesId(ctx context.Context, seriesId string) (*Blueprint, *http.Response, error) {

--- a/internal/provider/blueprint_common.go
+++ b/internal/provider/blueprint_common.go
@@ -19,10 +19,11 @@ type BlueprintResourceModel struct {
 	Description types.String `tfsdk:"description"`
 	Provider    types.String `tfsdk:"cloud_provider"`
 
-	Content    types.String `tfsdk:"content"`
-	Categories types.Set    `tfsdk:"categories"`
-	Guidance   types.String `tfsdk:"guidance"`
-	Labels     types.Set    `tfsdk:"labels"`
+	Content                       types.String `tfsdk:"content"`
+	Categories                    types.Set    `tfsdk:"categories"`
+	Guidance                      types.String `tfsdk:"guidance"`
+	Labels                        types.Set    `tfsdk:"labels"`
+	ExcludedContextQuestionSeries types.Set    `tfsdk:"excluded_context_question_series"`
 }
 
 func FlattenBlueprint(blueprint *client.Blueprint) BlueprintResourceModel {
@@ -51,6 +52,12 @@ func FlattenBlueprint(blueprint *client.Blueprint) BlueprintResourceModel {
 		categories = append(categories, basetypes.NewStringValue(category))
 	}
 	data.Categories = types.SetValueMust(basetypes.StringType{}, categories)
+
+	var excludedContextQuestionSeries []attr.Value
+	for _, excludedCQS := range blueprint.ExcludedContextQuestionSeries {
+		excludedContextQuestionSeries = append(excludedContextQuestionSeries, basetypes.NewStringValue(excludedCQS))
+	}
+	data.ExcludedContextQuestionSeries = types.SetValueMust(basetypes.StringType{}, excludedContextQuestionSeries)
 
 	return data
 }

--- a/internal/provider/blueprint_data_source.go
+++ b/internal/provider/blueprint_data_source.go
@@ -78,6 +78,11 @@ func (d *BlueprintDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Computed:            true,
 				MarkdownDescription: "",
 			},
+			"excluded_context_question_series": schema.SetAttribute{
+				ElementType:         basetypes.StringType{},
+				Computed:            true,
+				MarkdownDescription: "series_id for context questions that won't be used with this blueprint, even if this blueprint matches the context questions' blueprint_categories",
+			},
 		},
 	}
 }

--- a/internal/provider/blueprint_data_source_test.go
+++ b/internal/provider/blueprint_data_source_test.go
@@ -24,6 +24,7 @@ func TestAccBlueprintDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "categories.0", "BLUEPRINT_BLOB_STORAGE"),
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "labels.0", "marketing"),
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "guidance", "How to use this "),
+					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "excluded_context_question_series.#", "0"),
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "content",
 						`resource "aws_s3_bucket" "{{ resource_name }}" {
   bucket = "{{ bucket }}"

--- a/internal/provider/blueprint_resource.go
+++ b/internal/provider/blueprint_resource.go
@@ -139,6 +139,13 @@ func (r *BlueprintResource) Schema(
 					),
 				},
 			},
+			"excluded_context_question_series": schema.SetAttribute{
+				Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, nil)),
+				ElementType:         basetypes.StringType{},
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "series_id for context questions that won't be used with this blueprint, even if this blueprint matches the context questions' blueprint_categories",
+			},
 		},
 	}
 }
@@ -311,12 +318,13 @@ func (r *BlueprintResource) buildCommonFields(
 	plan BlueprintResourceModel,
 ) client.CommonBlueprintFields {
 	commonFields := client.CommonBlueprintFields{
-		Name:        plan.Name.ValueString(),
-		Description: plan.Description.ValueString(),
-		Content:     plan.Content.ValueString(),
-		Guidance:    plan.Guidance.ValueString(),
-		Categories:  nil,
-		Labels:      nil,
+		Name:                          plan.Name.ValueString(),
+		Description:                   plan.Description.ValueString(),
+		Content:                       plan.Content.ValueString(),
+		Guidance:                      plan.Guidance.ValueString(),
+		Categories:                    nil,
+		Labels:                        nil,
+		ExcludedContextQuestionSeries: nil,
 	}
 
 	var labels []string
@@ -326,6 +334,7 @@ func (r *BlueprintResource) buildCommonFields(
 	}
 
 	plan.Categories.ElementsAs(ctx, &commonFields.Categories, false)
+	plan.ExcludedContextQuestionSeries.ElementsAs(ctx, &commonFields.ExcludedContextQuestionSeries, false)
 
 	return commonFields
 }

--- a/internal/provider/blueprint_resource_test.go
+++ b/internal/provider/blueprint_resource_test.go
@@ -26,6 +26,7 @@ func TestAccBlueprintResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("resourcely_blueprint.basic", "categories.0", "BLUEPRINT_BLOB_STORAGE"),
 					resource.TestCheckResourceAttr("resourcely_blueprint.basic", "labels.0", "marketing"),
 					resource.TestCheckResourceAttr("resourcely_blueprint.basic", "guidance", "How to use this blueprint"),
+					resource.TestCheckResourceAttr("resourcely_blueprint.basic", "excluded_context_question_series.#", "0"),
 					resource.TestCheckResourceAttr("resourcely_blueprint.basic", "content",
 						`resource "aws_s3_bucket" "{{ resource_name }}" {
   bucket = "{{ bucket }}"


### PR DESCRIPTION
# What?
Add `excluded_context_question_series` to the `blueprint` resource.

# Testing?
Mostly manual. Acceptance tests only check for 'the empty set'. Our backend validates referential integrity, so testing with a non-empty set would require crud'ing context questions in the blueprint tests. Which we _could_ do, but I noticed we didn't do it for other relationships, so I didn't do it here.