### PR TITLE
ci: add Terraform 1.7 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
           - "1.4.*"
           - "1.5.*"
           - "1.6.*"
+          - "1.7.*"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0


### PR DESCRIPTION
## What?

Terraform 1.7 was released in January, so add that to our test matrix.

## Post-merge?

Add the associated status check to the required status checks.