### PR TITLE
internal/client guardrails: Indicate guardrail is terraform managed

### DIFF
--- a/internal/client/guardrails.go
+++ b/internal/client/guardrails.go
@@ -19,6 +19,7 @@ type Guardrail struct {
 
 type NewGuardrail struct {
 	CommonGuardrailFields
+	IsTerraformManaged bool `json:"is_terraform_managed"`
 }
 
 type UpdatedGuardrail struct {

--- a/internal/provider/guardrail_resource.go
+++ b/internal/provider/guardrail_resource.go
@@ -193,6 +193,7 @@ func (r *GuardrailResource) Create(
 			State:       plan.State.ValueString(),
 			Content:     plan.Content.ValueString(),
 		},
+		IsTerraformManaged: true,
 	}
 
 	guardrail, _, err := r.service.CreateGuardrail(ctx, newGuardrail)


### PR DESCRIPTION
Allows us to differentiate guardrails created in the portal vs via TF