### PR TITLE
blueprints: add support for `is_published` property

### DIFF
--- a/docs/data-sources/blueprint.md
+++ b/docs/data-sources/blueprint.md
@@ -19,6 +19,10 @@ A resourcely blueprint
 
 - `series_id` (String) UUID for the blueprint
 
+### Optional
+
+- `is_published` (Boolean) A published blueprint is available for use by developers to create resources through the Resourcely portal.
+
 ### Read-Only
 
 - `categories` (Set of String)

--- a/docs/resources/blueprint.md
+++ b/docs/resources/blueprint.md
@@ -27,6 +27,9 @@ A Resourcely Blueprint
 - `description` (String)
 - `excluded_context_question_series` (Set of String) series_id for context questions that won't be used with this blueprint, even if this blueprint matches the context questions' blueprint_categories
 - `guidance` (String)
+- `is_published` (Boolean) A published blueprint is available for use by developers to create resources through the Resourcely portal.
+
+If left unset, the blueprint will start as unpublished, and you may safely change this property in the Resourcely portal.
 - `labels` (Set of String)
 - `scope` (String)
 

--- a/internal/client/blueprints.go
+++ b/internal/client/blueprints.go
@@ -15,18 +15,25 @@ type Blueprint struct {
 	Version  int64  `json:"version"`
 	Scope    string `json:"scope"`
 	CommonBlueprintFields
-	Provider string `json:"provider"`
+	Provider    string `json:"provider"`
+	IsPublished bool   `json:"is_published"`
 }
 
 type NewBlueprint struct {
 	CommonBlueprintFields
 	Provider           string `json:"provider"`
 	IsTerraformManaged bool   `json:"is_terraform_managed"`
+	IsPublished        bool   `json:"is_published"`
 }
 
 type UpdatedBlueprint struct {
 	SeriesId string `json:"-"`
 	CommonBlueprintFields
+}
+
+type PatchedBlueprint struct {
+	SeriesId    string `json:"-"`
+	IsPublished bool   `json:"is_published"`
 }
 
 type CommonBlueprintFields struct {
@@ -60,6 +67,15 @@ func (s *BlueprintsService) CreateBlueprint(ctx context.Context, newBlueprint *N
 func (s *BlueprintsService) UpdateBlueprint(ctx context.Context, updatedBlueprint *UpdatedBlueprint) (*Blueprint, *http.Response, error) {
 	path := fmt.Sprintf("%s/blueprints/series/%s", s.Client.BasePath, updatedBlueprint.SeriesId)
 	body, resp, err := s.Client.Put(ctx, path, updatedBlueprint, new(Blueprint))
+	if err != nil {
+		return nil, resp, err
+	}
+	return body.(*Blueprint), resp, nil
+}
+
+func (s *BlueprintsService) PatchBlueprint(ctx context.Context, patchedBlueprint *PatchedBlueprint) (*Blueprint, *http.Response, error) {
+	path := fmt.Sprintf("%s/blueprints/series/%s", s.Client.BasePath, patchedBlueprint.SeriesId)
+	body, resp, err := s.Client.Patch(ctx, path, patchedBlueprint, new(Blueprint))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -96,6 +96,15 @@ func (c *Client) Put(ctx context.Context, path string, fields interface{}, respB
 	return c.MakeRequest(ctx, req, respBody)
 }
 
+// patch makes patch requests to the given path with the given fields and stores the response in the given body object.
+func (c *Client) Patch(ctx context.Context, path string, fields interface{}, respBody interface{}) (interface{}, *http.Response, error) {
+	req, err := c.NewRequest("PATCH", path, fields)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.MakeRequest(ctx, req, respBody)
+}
+
 // delete makes delete requests to the given path.
 func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error) {
 	req, err := c.NewRequest("DELETE", path, nil)

--- a/internal/provider/blueprint_common.go
+++ b/internal/provider/blueprint_common.go
@@ -18,6 +18,7 @@ type BlueprintResourceModel struct {
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	Provider    types.String `tfsdk:"cloud_provider"`
+	IsPublished types.Bool   `tfsdk:"is_published"`
 
 	Content                       types.String `tfsdk:"content"`
 	Categories                    types.Set    `tfsdk:"categories"`
@@ -37,6 +38,7 @@ func FlattenBlueprint(blueprint *client.Blueprint) BlueprintResourceModel {
 	data.Name = types.StringValue(blueprint.Name)
 	data.Description = types.StringValue(blueprint.Description)
 	data.Provider = types.StringValue(blueprint.Provider)
+	data.IsPublished = types.BoolValue(blueprint.IsPublished)
 
 	data.Content = types.StringValue(blueprint.Content)
 	data.Guidance = types.StringValue(blueprint.Guidance)

--- a/internal/provider/blueprint_data_source.go
+++ b/internal/provider/blueprint_data_source.go
@@ -78,6 +78,11 @@ func (d *BlueprintDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Computed:            true,
 				MarkdownDescription: "",
 			},
+			"is_published": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "A published blueprint is available for use by developers to create resources through the Resourcely portal.",
+			},
 			"excluded_context_question_series": schema.SetAttribute{
 				ElementType:         basetypes.StringType{},
 				Computed:            true,

--- a/internal/provider/blueprint_data_source_test.go
+++ b/internal/provider/blueprint_data_source_test.go
@@ -25,6 +25,7 @@ func TestAccBlueprintDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "labels.0", "marketing"),
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "guidance", "How to use this "),
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "excluded_context_question_series.#", "0"),
+					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "is_published", "true"),
 					resource.TestCheckResourceAttr("data.resourcely_blueprint.by_series_id", "content",
 						`resource "aws_s3_bucket" "{{ resource_name }}" {
   bucket = "{{ bucket }}"
@@ -49,6 +50,8 @@ resource "resourcely_blueprint" "basic" {
                 bucket = "{{ bucket }}"
               }
             EOT
+
+  is_published = true
 }
 
 data "resourcely_blueprint" "by_series_id" {


### PR DESCRIPTION
## What?

Add support for the `is_published` property on blueprints.

This one is a bit more tricky than a usual property.  `is_published` is mutable property on the current version of the blueprint. Changing it does not create a new version. So, it is not changed via the normal update `PUT` API call, but instead, uses a special `PATCH` API call. 

The PR introduces special logic into the blueprint `Update` function to handle this:
- check which properties have changed
- if only `is_published`, just call the patch endpoint
- if only other fields, just call the put endpoint
- if both, call both

`is_published` is also designed to be toggled outside of Terraform.  To support this, the new `is_published` property is optional.  If it a value is not explicitly specified, the provider will not attempt to set a value.  Each refresh (Read) will simply update the state with the latest value from the backend.

## Testing?

1. I updated the `blueprint_resource` acceptance tests to verify that
    - `is_published` can be updated
    -  a regular field (`name`) can still be updated
    -  unsetting `is_published` retains the server-side value in the TF state

2. I also tested several flows manually in dev
    - Leave `is_published` unset in Terraform.  Changes via the portal are reflected via `terraform refresh; terraform show`, but the `terraform plan` is always still clean.
    - Change `is_published` via Terraform.  The portal reflects the value applied by Terraform.  A change via the portal results in a dirty `terraform plan`.
    - Change both `is_published` and another field (the complex-valued `labels`) via Terraform.   Both changes are applied cleanly.
    - Unset `is_published` in Terraform.  Changes via the portal are again reflected via `terraform refresh; terraform show`, but the `terraform plan` remains clean.