### PR TITLE
context_question_*_test: use random labels to avoid unique constraint errors

### DIFF
--- a/internal/provider/context_question_data_source_test.go
+++ b/internal/provider/context_question_data_source_test.go
@@ -1,20 +1,24 @@
 package provider
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccContextQuestionDataSource_basic(t *testing.T) {
+	rLabel := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccContextQuestionDataSourceConfig_basic,
+				Config: testAccContextQuestionDataSourceConfig_basic(rLabel),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("data.resourcely_context_question.by_series_id", "id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
 					resource.TestMatchResourceAttr("data.resourcely_context_question.by_series_id", "series_id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
@@ -22,7 +26,7 @@ func TestAccContextQuestionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "qtype", "QTYPE_SINGLE_SELECT"),
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "blueprint_categories.0", "BLUEPRINT_BLOB_STORAGE"),
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "answer_choices.0.label", "tenant-context Option 1"),
-					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "label", "marketing"),
+					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "label", rLabel),
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "regex_pattern", "regex"),
 					resource.TestCheckResourceAttr("data.resourcely_context_question.by_series_id", "priority", "2"),
 				),
@@ -31,14 +35,15 @@ func TestAccContextQuestionDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccContextQuestionDataSourceConfig_basic = `
+func testAccContextQuestionDataSourceConfig_basic(label string) string {
+	return fmt.Sprintf(`
 resource "resourcely_context_question" "basic" {
 	prompt = "what is your prompt?"
 	qtype = "QTYPE_SINGLE_SELECT"
 	scope = "SCOPE_TENANT"
 	blueprint_categories = ["BLUEPRINT_BLOB_STORAGE"]
 	answer_choices = [{label: "tenant-context Option 1"}]
-	label = "marketing"
+	label = "%s"
 	regex_pattern = "regex"
 	excluded_blueprint_series = []
 	priority = 2
@@ -47,4 +52,5 @@ resource "resourcely_context_question" "basic" {
 data "resourcely_context_question" "by_series_id" {
   series_id = resourcely_context_question.basic.series_id
 }
-`
+`, label)
+}

--- a/internal/provider/context_question_resource_test.go
+++ b/internal/provider/context_question_resource_test.go
@@ -5,18 +5,21 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccContextQuestionResource_basic(t *testing.T) {
+	rLabel := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccContextQuestionResourceConfig_basic("what is your prompt?"),
+				Config: testAccContextQuestionResourceConfig_basic(rLabel, "what is your prompt?"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("resourcely_context_question.basic", "id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
 					resource.TestMatchResourceAttr("resourcely_context_question.basic", "series_id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
@@ -24,7 +27,7 @@ func TestAccContextQuestionResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "qtype", "QTYPE_SINGLE_SELECT"),
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "blueprint_categories.0", "BLUEPRINT_BLOB_STORAGE"),
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "answer_choices.0.label", "tenant-context Option 1"),
-					resource.TestCheckResourceAttr("resourcely_context_question.basic", "label", "marketing"),
+					resource.TestCheckResourceAttr("resourcely_context_question.basic", "label", rLabel),
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "regex_pattern", `regex`),
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "priority", "2"),
 				),
@@ -38,7 +41,7 @@ func TestAccContextQuestionResource_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccContextQuestionResourceConfig_basic("basic_test_update"),
+				Config: testAccContextQuestionResourceConfig_basic(rLabel, "basic_test_update"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("resourcely_context_question.basic", "prompt", "basic_test_update"),
 				),
@@ -49,13 +52,15 @@ func TestAccContextQuestionResource_basic(t *testing.T) {
 }
 
 func TestAccContextQuestionResource_useDefaults(t *testing.T) {
+	rLabel := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccContextQuestionResourceConfig_useDefaults("what is your prompt?"),
+				Config: testAccContextQuestionResourceConfig_useDefaults(rLabel, "what is your prompt?"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("resourcely_context_question.usedefaults", "id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
 					resource.TestMatchResourceAttr("resourcely_context_question.usedefaults", "series_id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
@@ -63,7 +68,7 @@ func TestAccContextQuestionResource_useDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "qtype", "QTYPE_TEXT"),
 					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "blueprint_categories.0", "BLUEPRINT_BLOB_STORAGE"),
 					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "priority", "0"),
-					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "label", "marketing"),
+					resource.TestCheckResourceAttr("resourcely_context_question.usedefaults", "label", rLabel),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -85,7 +90,7 @@ func importContextQuestionBySeriesId(contextQuestionName string) resource.Import
 	}
 }
 
-func testAccContextQuestionResourceConfig_basic(prompt string) string {
+func testAccContextQuestionResourceConfig_basic(label, prompt string) string {
 	return fmt.Sprintf(`
 resource "resourcely_context_question" "basic" {
 	prompt = "%s"
@@ -93,22 +98,22 @@ resource "resourcely_context_question" "basic" {
 	scope = "SCOPE_TENANT"
 	blueprint_categories = ["BLUEPRINT_BLOB_STORAGE"]
 	answer_choices = [{label: "tenant-context Option 1"}]
-	label = "marketing"
+	label = "%s"
 	regex_pattern = "regex"
 	excluded_blueprint_series = []
 	priority = 2
 }
-`, prompt)
+`, prompt, label)
 }
 
-func testAccContextQuestionResourceConfig_useDefaults(prompt string) string {
+func testAccContextQuestionResourceConfig_useDefaults(label, prompt string) string {
 	return fmt.Sprintf(`
 resource "resourcely_context_question" "usedefaults" {
 	prompt = "%s"
 	qtype = "QTYPE_TEXT"
 	scope = "SCOPE_TENANT"
 	blueprint_categories = ["BLUEPRINT_BLOB_STORAGE"]
-	label = "marketing"
+	label = "%s"
 }
-`, prompt)
+`, prompt, label)
 }


### PR DESCRIPTION
## What?

Modify the acceptance tests for `resourcely_context_question` resource & data source to use randomly generated labels.

## Why?

The new uniqueness constraints in the backend cause failures when concurrent tests try to use the same hardcoded values.