### PR TITLE
guardrails: support template-backed guardrails

### DIFF
--- a/internal/client/guardrails.go
+++ b/internal/client/guardrails.go
@@ -14,17 +14,31 @@ type Guardrail struct {
 	SeriesId string `json:"series_id"`
 	Version  int64  `json:"version"`
 	Scope    string `json:"scope"`
+
 	CommonGuardrailFields
+
+	GuardrailTemplate struct {
+		SeriesId string `json:"series_id"`
+	} `json:"guardrail_template"`
+	GuardrailTemplateInputs interface{} `json:"guardrail_template_inputs"`
 }
 
 type NewGuardrail struct {
 	CommonGuardrailFields
+
+	GuardrailTemplateSeriesId string      `json:"guardrail_template_series_id"`
+	GuardrailTemplateInputs   interface{} `json:"guardrail_template_inputs"`
+
 	IsTerraformManaged bool `json:"is_terraform_managed"`
 }
 
 type UpdatedGuardrail struct {
 	SeriesId string `json:"-"`
+
 	CommonGuardrailFields
+
+	GuardrailTemplateSeriesId string      `json:"guardrail_template_series_id"`
+	GuardrailTemplateInputs   interface{} `json:"guardrail_template_inputs"`
 }
 
 type CommonGuardrailFields struct {

--- a/internal/provider/guardrail_data_source.go
+++ b/internal/provider/guardrail_data_source.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Resourcely-Inc/terraform-provider-resourcely/internal/client"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
@@ -72,6 +73,15 @@ func (d *GuardrailDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				MarkdownDescription: "",
 				Computed:            true,
 			},
+			"guardrail_template_series_id": schema.StringAttribute{
+				MarkdownDescription: "The series id of the guardrail template used to render the policies",
+				Computed:            true,
+			},
+			"guardrail_template_inputs": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
+				MarkdownDescription: "A JSON encoding of values for the guardrail template inputs.\n\nExample: `guardrail_template_inputs = jsonencode({inputOne = \"value one\"})`",
+				Computed:            true,
+			},
 		},
 	}
 }
@@ -116,7 +126,7 @@ func (d *GuardrailDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	// Overwrite state with refreshed value
-	state := FlattenGuardrail(guardrail)
-
+	var state GuardrailResourceModel
+	resp.Diagnostics.Append(FlattenGuardrail(guardrail, &state)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/provider/guardrail_resource_test.go
+++ b/internal/provider/guardrail_resource_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccGuardrailResource_basic(t *testing.T) {
+func TestAccGuardrailResource_basic_withContent(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccGuardrailResourceConfig_basic("basic_test"),
+				Config: testAccGuardrailResourceConfig_basic_withContent("basic_test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("resourcely_guardrail.basic", "id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
 					resource.TestMatchResourceAttr("resourcely_guardrail.basic", "series_id", regexp.MustCompile("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$")),
@@ -41,7 +41,7 @@ func TestAccGuardrailResource_basic(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccGuardrailResourceConfig_basic("basic_test_update"),
+				Config: testAccGuardrailResourceConfig_basic_withContent("basic_test_update"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("resourcely_guardrail.basic", "name", "basic_test_update"),
 				),
@@ -65,7 +65,7 @@ func importGuardrailBySeriesId(guardrailName string) resource.ImportStateIdFunc 
 	}
 }
 
-func testAccGuardrailResourceConfig_basic(name string) string {
+func testAccGuardrailResourceConfig_basic_withContent(name string) string {
 	return fmt.Sprintf(`
 resource "resourcely_guardrail" "basic" {
   name = "%s"
@@ -81,3 +81,133 @@ resource "resourcely_guardrail" "basic" {
 }
 `, name)
 }
+
+// Where is
+// testAccGuardrailResourceConfig_basic_withGuardrailTemplate?
+//
+// That test would require an actual guardrail template to exist,
+// which we can't safely do.
+//
+// The test can't create one, because templates are managed by the
+// Resourcely platform. This provider does not have a
+// "guardrail_template" resource.
+//
+// And the test cannot hardcode a template provided by the Resourcely
+// platform becuase the template series ids differ in each
+// environment. These tests should pass in both our dev and prod
+// environments.
+//
+// If this becomes a problem, we could introduce a "guardrail
+// template" data source into this provider.  The data source could
+// lookup a specific guardrail template by an attribute that is
+// consistent across all environments (e.g., name).
+
+func TestAccGuardrailResource_errorsMissingInputs(t *testing.T) {
+	expectedErrorsValidatorErrorMissingInputs := []string{
+		"These attributes must be configured together",
+		"guardrail_template_series_id",
+		"guardrail_template_inputs",
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ErrorCheck:               ErrorCheckExpectedErrorMessagesContaining(t, expectedErrorsValidatorErrorMissingInputs...),
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccGuardrailResourceConfig_configValidatorErrorMissingInputs,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("resourcely_guardrail.guardrail_template", "guardrail_template_inputs"),
+				),
+			},
+		},
+	})
+}
+
+const testAccGuardrailResourceConfig_configValidatorErrorMissingInputs = `
+resource "resourcely_guardrail" "guardrail_template" {
+  name           = "basic_test"
+  description    = "this is a basic test"
+  cloud_provider = "PROVIDER_AMAZON"
+  category       = "GUARDRAIL_BEST_PRACTICES"
+
+  guardrail_template_series_id = "00000000-00000000-00000000-00000000"
+}
+`
+
+func TestAccGuardrailResource_errorsConflicting(t *testing.T) {
+	expectedErrorsValidatorErrorConflicting := []string{
+		"Exactly one of these attributes must be configured",
+		"content",
+		"guardrail_template_series_id",
+		"guardrail_template_inputs",
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ErrorCheck:               ErrorCheckExpectedErrorMessagesContaining(t, expectedErrorsValidatorErrorConflicting...),
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccGuardrailResourceConfig_configValidatorErrorConflicting,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("resourcely_guardrail.guardrail_template", "guardrail_template_inputs"),
+				),
+			},
+		},
+	})
+}
+
+const testAccGuardrailResourceConfig_configValidatorErrorConflicting = `
+resource "resourcely_guardrail" "guardrail_template" {
+  name           = "basic_test"
+  description    = "this is a basic test"
+  cloud_provider = "PROVIDER_AMAZON"
+  category       = "GUARDRAIL_BEST_PRACTICES"
+
+  content = <<-EOT
+  guardrail "basic test"
+	when aws_s3_bucket
+	require bucket = "acme-{team}-{project}"
+  end
+EOT
+
+  guardrail_template_series_id = "00000000-00000000-00000000-00000000"
+  guardrail_template_inputs    = "{\"test\": \"render test\"}"
+}
+`
+
+func TestAccGuardrailResource_errorsInvalidJSON(t *testing.T) {
+	expectedErrorsValidatorErrorConflicting := []string{
+		"Exactly one of these attributes must be configured",
+		"content",
+		"guardrail_template_series_id",
+		"guardrail_template_inputs",
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ErrorCheck:               ErrorCheckExpectedErrorMessagesContaining(t, expectedErrorsValidatorErrorConflicting...),
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccGuardrailResourceConfig_configValidatorErrorInvalidJSON,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("resourcely_guardrail.guardrail_template", "guardrail_template_inputs"),
+				),
+			},
+		},
+	})
+}
+
+const testAccGuardrailResourceConfig_configValidatorErrorInvalidJSON = `
+resource "resourcely_guardrail" "guardrail_template" {
+  name           = "basic_test"
+  description    = "this is a basic test"
+  cloud_provider = "PROVIDER_AMAZON"
+  category       = "GUARDRAIL_BEST_PRACTICES"
+
+  guardrail_template_series_id = "00000000-00000000-00000000-00000000"
+  guardrail_template_inputs    = ""
+}
+`


### PR DESCRIPTION
## What?

Teach the `resourcely_guardrail` resource about template-backed guardrails. 

Original guardrails are created from the Really `content` directly.
```
resource "resourcely_guardrail" "with_content" {
   name           = "..."
   description = "..."

   content = <<EOT
   GUARDRAIL "example"
      WHEN resource
         REQUIRE prop = "foo"
   EOT
}
```

A template-backed guardrail is created by rendering a guardrail template with some inputs, rather than specifying the Really content:
```
resource "resourcely_guardrail" "with_content" {
   name           = "..."
   description = "..."

   guardrail_template_series_id = "<uuid>"
   guardrail_template_inputs      = jsonencode({
      varA = "...",
      varB = "...",
   })
}
```

## Why?

Two reasons. Completeness in the provider and to support the "copy to clipboard" feature in Guardrail Foundry.

## Testing?

There are new automated tests to verify that:
- the provider rejects a config that tries to specify both content and a guardrail template.
- the provider rejects a config that specifies a guardrail template, but not its inputs.
- the provider rejects a config that specifies an invalid json string (e.g., the empty string) for the template inputs.

Notably, there is _not_ a test for the happy path.  See the comment in `resource_guardrail_test.go` for an explanation of why (TL;DR: these tests have no safe way to create or reference a real guardrail template).

I manually tested the happy path using a local config root and a hardcoded template series id pulled from the database.