### PR TITLE
docs: fix capitalization of the provider name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 page_title: "Provider: resourcely"
 ---
 
-# RESOURCELY Provider
+# Resourcely Provider
 
 The Resourcely provider is used to manage Resourcely blueprint,
 guardrails, global values, and more through Terraform. The provider

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -2,7 +2,7 @@
 page_title: "Provider: resourcely"
 ---
 
-# {{ .ProviderShortName | upper }} Provider
+# {{ .ProviderShortName | title }} Provider
 
 The Resourcely provider is used to manage Resourcely blueprint,
 guardrails, global values, and more through Terraform. The provider


### PR DESCRIPTION
## What?

Fix the capitalization of the provider name in the provider docs page:

`RESOURCELY Provider` -> `Resourcely Provider`